### PR TITLE
Make Eyeleo more responsive to change in the number of displays

### DIFF
--- a/source/code/beforepause_wnd.cpp
+++ b/source/code/beforepause_wnd.cpp
@@ -13,13 +13,13 @@ BEGIN_EVENT_TABLE(BeforePauseWindow, wxFrame)
 END_EVENT_TABLE()
 
 
-BeforePauseWindow::BeforePauseWindow(int displayInd, int postponeCount) :
+BeforePauseWindow::BeforePauseWindow(const DisplayData& displayData, int postponeCount) :
 	wxFrame(NULL, -1, L"", wxDefaultPosition, wxDefaultSize, wxFRAME_TOOL_WINDOW | wxFRAME_SHAPED | wxNO_BORDER | wxFRAME_NO_TASKBAR | wxSTAY_ON_TOP),
 	_preventClosing(true),
 	_readyTimer((float)eyeleo::settings::timeForLongBreakConfirmation),
 	_result(RESULT_NONE),
 	_postponeCount(postponeCount),
-	_displayInd(displayInd),
+	_displayData(displayData),
 	_btnReady(nullptr),
 	_showing(true),
 	_hiding(false),
@@ -43,8 +43,7 @@ void BeforePauseWindow::Init()
 
 	// Set position to center of the screen
 	SetSize(wxSize(_backBitmap->GetWidth(), _backBitmap->GetHeight()));
-	assert(_displayInd < osCaps.numDisplays);
-	wxRect displayRect = osCaps.displays[_displayInd].clientArea;
+	wxRect displayRect = _displayData.clientArea;
 	SetPosition(wxPoint(displayRect.GetX() + displayRect.GetWidth() / 2 - GetSize().GetX() / 2, displayRect.GetY() + displayRect.GetHeight() / 2 - GetSize().GetY() / 2));
 
 	wxStaticText * txt = new wxStaticText(this, wxID_ANY, langPack->Get("before_pause_text"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTRE);

--- a/source/code/beforepause_wnd.h
+++ b/source/code/beforepause_wnd.h
@@ -4,6 +4,7 @@
 #include "wx/wx.h"
 #include "wx/timer.h"
 #include "task_mgr.h"
+#include "oscapabilities.h"
 
 enum
 {
@@ -23,7 +24,7 @@ enum EResult
 class BeforePauseWindow : public wxFrame, public ITask
 {
 public:
-	BeforePauseWindow(int displayInd = 0, int postponeCount = 0);
+	BeforePauseWindow(const DisplayData& displayData, int postponeCount = 0);
 	virtual ~BeforePauseWindow();
 
 	void Init();
@@ -32,7 +33,6 @@ public:
 
 private:
 	void OnPaint(wxPaintEvent& evt);
-	void OnErase(wxEraseEvent& evt);
 	void ExecuteTask(float f, long time_went);
 	void OnClose(wxCloseEvent& event);
 	
@@ -42,7 +42,7 @@ private:
 
 	void UpdateReadyTimer();
 
-	int _displayInd;
+	DisplayData _displayData;
 	int _postponeCount;
 
 	bool _showing;

--- a/source/code/bigpause_wnd.cpp
+++ b/source/code/bigpause_wnd.cpp
@@ -18,21 +18,21 @@ BEGIN_EVENT_TABLE(BigPauseWindow, wxFrame)
 	EVT_KILL_FOCUS(BigPauseWindow::OnKillFocus)
 END_EVENT_TABLE()
 
-BigPauseWindow::BigPauseWindow(int displayInd) :
+BigPauseWindow::BigPauseWindow(const DisplayData& displayData) :
 	wxFrame(NULL, -1, L"", wxDefaultPosition, wxDefaultSize, wxFRAME_SHAPED | wxFRAME_NO_TASKBAR | wxSTAY_ON_TOP),
 	_preventClosing(true),
 	_breakTimeLeft(0),
 	_breakTimeFull(0),
 	_timeText(0),
 	_restoreFocus(false),
-	_displayInd(displayInd),
+	_displayData(displayData),
 	_showing(true),
 	_hiding(false),
 	_alpha(0.0f),
 	_primary(false),
 	_sizer(nullptr)
 {
-	SetName(std::string("BigPauseWindow") + (char)('0' + displayInd));
+	SetName(std::string("BigPauseWindow") + (char)('0' + displayData.ind));
 
 	logging::msg("BigPauseWindow::BigPauseWindow");
 }
@@ -41,8 +41,7 @@ void BigPauseWindow::Init()
 {
 	refillResolutionParams();
 
-	assert(_displayInd < osCaps.numDisplays);
-	wxRect displayRect = osCaps.displays[_displayInd].geometry;
+	wxRect displayRect = _displayData.geometry;
 
 	SetPosition(displayRect.GetPosition());
 
@@ -51,7 +50,7 @@ void BigPauseWindow::Init()
 	_showing = true;
 	_hiding = false;
 	_alpha = 0.0f;
-	_primary = _displayInd == osCaps.primaryDisplayInd;
+	_primary = _displayData.primary;
 
 	SetBackgroundColour(wxColour(0, 0, 0));
 	SetTransparent((int)_alpha);

--- a/source/code/bigpause_wnd.h
+++ b/source/code/bigpause_wnd.h
@@ -4,6 +4,7 @@
 #include "wx/wx.h"
 #include "wx/timer.h"
 #include "task_mgr.h"
+#include "oscapabilities.h"
 
 enum
 {
@@ -13,7 +14,7 @@ enum
 class BigPauseWindow : public wxFrame, public ITask
 {
 public:
-	BigPauseWindow(int displayInd = 0);
+	BigPauseWindow(const DisplayData& displayData);
 	virtual ~BigPauseWindow();
 
 	virtual void Init();
@@ -42,7 +43,7 @@ private:
 	float _breakTimeFull;
 	bool _primary;
 
-	int _displayInd;
+	DisplayData _displayData;
 
 	wxStaticText * _timeText;
 	wxBoxSizer * _sizer;

--- a/source/code/main.h
+++ b/source/code/main.h
@@ -106,7 +106,8 @@ public:
 	void SetInactivityTrackingEnabled(bool enabled) { _settingInactivityTracking = enabled; }
 	void SetCanCloseNotificationsSetting(bool enabled) { _settingCanCloseNotifications = enabled; }
 
-	bool IsFullscreenAppRunning(int * display = 0, HWND * fullscreenWndHandle = 0) const;
+	bool IsFullscreenAppRunning(HWND * fullscreenWndHandle = nullptr) const;
+	int GetFullScreenAppRunningDisplay(HWND * fullscreenWndHandle = nullptr) const;
 	
 	void TogglePausedMode(int minites = 0);
 	bool isPausedMode() const;

--- a/source/code/minipause_wnd.cpp
+++ b/source/code/minipause_wnd.cpp
@@ -39,16 +39,16 @@ int MiniPauseControls::_excercise = 0;
 int MiniPauseControls::_line = 0;
 int MiniPauseControls::_lastExcercise = 0;
 
-MiniPauseWindow::MiniPauseWindow(int displayInd, unsigned int showCount) :
+MiniPauseWindow::MiniPauseWindow(const DisplayData& displayData, unsigned int showCount) :
 	wxFrame(NULL, -1, L"", wxDefaultPosition, wxDefaultSize, wxFRAME_TOOL_WINDOW | wxFRAME_SHAPED | wxNO_BORDER | wxFRAME_NO_TASKBAR | wxSTAY_ON_TOP),
 	_preventClosing(true),
 	_controlsWnd(0),
 	_showCount(showCount),
-	_displayInd(displayInd),
+	_displayData(displayData),
 	_state(STATE_SHOWING),
 	_alpha(0.0f)
 {
-	SetName(std::string("MiniPauseWindow") + (char)('0' + displayInd));
+	SetName(std::string("MiniPauseWindow") + (char)('0' + displayData.ind));
 }
 
 void MiniPauseWindow::Init()
@@ -62,8 +62,7 @@ void MiniPauseWindow::Init()
 	SetTransparent(0);
 
 	SetSize(_backBitmap->GetSize());
-	assert(_displayInd < osCaps.numDisplays);
-	wxRect displayRect = osCaps.displays[_displayInd].clientArea;
+	wxRect displayRect = _displayData.clientArea;
 	SetPosition(wxPoint(displayRect.GetX() + displayRect.GetWidth() / 2 - GetSize().GetX() / 2, displayRect.GetY() + displayRect.GetHeight() / 2 - GetSize().GetY() / 2));
 
 	_state = MiniPauseWindow::STATE_SHOWING;
@@ -73,7 +72,7 @@ void MiniPauseWindow::Init()
 	Show(true);
 
 	_controlsWnd = new MiniPauseControls(this);
-	_controlsWnd->Init(_displayInd, _showCount);
+	_controlsWnd->Init(_displayData, _showCount);
 	_controlsWnd->Show(true);
 }
 
@@ -199,7 +198,7 @@ MiniPauseControls::MiniPauseControls(wxWindow * parent) :
 	
 }
 
-void MiniPauseControls::Init(int displayInd, unsigned int showCount)
+void MiniPauseControls::Init(const DisplayData& displayData, unsigned int showCount)
 {
 	if ((GetExtraStyle() & WS_EX_LAYERED) == 0 )
 		SetWindowLong(GetHWND(), GWL_EXSTYLE, GetExtraStyle() | WS_EX_LAYERED);
@@ -208,8 +207,7 @@ void MiniPauseControls::Init(int displayInd, unsigned int showCount)
 
 	// Set position to center of the screen
 	SetSize(wxSize(_backBitmap->GetWidth(), _backBitmap->GetHeight()));
-	assert(displayInd < osCaps.numDisplays);
-	wxRect displayRect = osCaps.displays[displayInd].clientArea;
+	wxRect displayRect = displayData.clientArea;
 	SetPosition(wxPoint(displayRect.GetX() + displayRect.GetWidth() / 2 - GetSize().GetX() / 2, displayRect.GetY() + displayRect.GetHeight() / 2 - GetSize().GetY() / 2));
 
 	wxStaticText * txt = new wxStaticText(this, ID_MINIPAUSE_TEXT, L"", wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);

--- a/source/code/minipause_wnd.h
+++ b/source/code/minipause_wnd.h
@@ -4,6 +4,7 @@
 #include "wx/wx.h"
 #include "wx/timer.h"
 #include "task_mgr.h"
+#include "oscapabilities.h"
 
 class MiniPauseControls;
 class MiniPauseWindow : public wxFrame, public ITask
@@ -17,7 +18,7 @@ class MiniPauseWindow : public wxFrame, public ITask
 	};
 
 public:
-	MiniPauseWindow(int displayInd = 0, unsigned int showCount = 0);
+	MiniPauseWindow(const DisplayData& displayData, unsigned int showCount = 0);
 	virtual ~MiniPauseWindow();
 
 	virtual void Init();
@@ -35,7 +36,7 @@ private:
 
 	int _timeLeft;
 	int _showCount;
-	int _displayInd;
+    DisplayData _displayData;
 
 	float _alpha;
 	bool _preventClosing;
@@ -58,7 +59,7 @@ public:
 	MiniPauseControls(wxWindow * parent = 0);
 	virtual ~MiniPauseControls();
 
-	void Init(int displayInd = 0, unsigned int showCount = 0);
+	void Init(const DisplayData& displayData, unsigned int showCount = 0);
 
 	void Update();
 

--- a/source/code/notification_wnd.cpp
+++ b/source/code/notification_wnd.cpp
@@ -31,7 +31,7 @@ NotificationWindow::NotificationWindow(unsigned int showCount) :
 	SetName("NotificationWindow");
 }
 
-void NotificationWindow::Init(int displayInd)
+void NotificationWindow::Init(const DisplayData& displayData)
 {
 	assert(!NotificationWindow::isInstanceExist);
 	NotificationWindow::isInstanceExist = true;
@@ -45,8 +45,7 @@ void NotificationWindow::Init(int displayInd)
 	SetTransparent(0);
 
 	SetSize(_backBitmap_notification->GetSize());
-	assert(displayInd < osCaps.numDisplays);
-	wxRect displayRect = osCaps.displays[displayInd].clientArea;
+	wxRect displayRect = displayData.clientArea;
 	SetPosition(wxPoint(displayRect.GetRight() - GetSize().GetX(), 
 		displayRect.GetBottom() - GetSize().GetY()));
 
@@ -57,7 +56,7 @@ void NotificationWindow::Init(int displayInd)
 	Show(true);
 
 	_controlsWnd = new NotificationWindowLook(this);
-	_controlsWnd->Init(displayInd, _showCount);
+	_controlsWnd->Init(displayData, _showCount);
 	_controlsWnd->Show(true);
 }
 
@@ -177,7 +176,7 @@ NotificationWindowLook::NotificationWindowLook(wxWindow * parent) :
 {
 }
 
-void NotificationWindowLook::Init(int displayInd, unsigned int showCount)
+void NotificationWindowLook::Init(const DisplayData& displayData, unsigned int showCount)
 {
 	(void)showCount;
 
@@ -188,8 +187,7 @@ void NotificationWindowLook::Init(int displayInd, unsigned int showCount)
 
 	// Set position to right bottom side of the screen
 	SetSize(_backBitmap_notification->GetSize());
-	assert(displayInd < osCaps.numDisplays);
-	wxRect displayRect = osCaps.displays[displayInd].clientArea;
+	wxRect displayRect = displayData.clientArea;
 	SetPosition(wxPoint(displayRect.GetRight() - GetSize().GetX(), 
 		displayRect.GetBottom() - GetSize().GetY()));
 

--- a/source/code/notification_wnd.h
+++ b/source/code/notification_wnd.h
@@ -4,6 +4,7 @@
 #include "wx/wx.h"
 #include "wx/timer.h"
 #include "task_mgr.h"
+#include "oscapabilities.h"
 
 class NotificationWindowLook;
 class NotificationWindow : public wxFrame, public ITask
@@ -34,7 +35,7 @@ public:
 	NotificationWindow(unsigned int showCount = 0);
 	virtual ~NotificationWindow();
 
-	void Init(int displayInd = 0);
+	void Init(const DisplayData& displayData);
 	void SetTime(int timeBeforeLongBreakMs); // сколько времени осталось до большого перерыва
 
 	virtual bool Hide();
@@ -52,7 +53,7 @@ public:
 	NotificationWindowLook(wxWindow * parent = 0);
 	virtual ~NotificationWindowLook();
 
-	void Init(int displayInd, unsigned int showCount);
+	void Init(const DisplayData& displayData, unsigned int showCount);
 
 	void Update();
 	

--- a/source/code/oscapabilities.h
+++ b/source/code/oscapabilities.h
@@ -6,26 +6,13 @@
 
 struct DisplayData
 {
+    int ind;
 	bool primary;
 	wxRect clientArea;
 	wxRect geometry;
 };
 
-struct OSCapabilities
-{
-	bool transparent_windows;
-	bool semi_transparent_windows;
-
-	int numDisplays;
-	bool multiDisplay;
-	int primaryDisplayInd;
-
-	std::vector<DisplayData> displays;
-};
-
-extern OSCapabilities osCaps;
-
-void fillOSCapabilities();
+std::vector<DisplayData> getDisplays();
 void refillResolutionParams();
 
 #endif

--- a/source/code/waiting_wnd.cpp
+++ b/source/code/waiting_wnd.cpp
@@ -19,9 +19,9 @@ WaitingFullscreenWindow::WaitingFullscreenWindow() :
 {
 }
 
-void WaitingFullscreenWindow::Init(int displayInd)
+void WaitingFullscreenWindow::Init(const DisplayData& displayData)
 {
-	SetName(wxString("WaitingFullscreenWindow") + (char)('0' + displayInd));
+	SetName(wxString("WaitingFullscreenWindow") + (char)('0' + displayData.ind));
 
 	refillResolutionParams();
 
@@ -32,8 +32,7 @@ void WaitingFullscreenWindow::Init(int displayInd)
 
 	// Set position to center of the screen
 	SetSize(wxSize(_backBitmap_long->GetWidth(), _backBitmap_long->GetHeight()));
-	assert(displayInd < osCaps.numDisplays);
-	wxRect displayRect = osCaps.displays[displayInd].clientArea;
+	wxRect displayRect = displayData.clientArea;
 	SetPosition(wxPoint(displayRect.GetX() + displayRect.GetWidth() / 2 - GetSize().GetX() / 2, displayRect.GetY() + displayRect.GetHeight() / 2 - GetSize().GetY() / 2));
 
 	wxStaticText * txt = new wxStaticText(this, wxID_ANY, langPack->Get("waiting_text"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);

--- a/source/code/waiting_wnd.h
+++ b/source/code/waiting_wnd.h
@@ -4,6 +4,7 @@
 #include "wx/wx.h"
 #include "wx/timer.h"
 #include "task_mgr.h"
+#include "oscapabilities.h"
 
 class WaitingFullscreenWindow : public wxFrame, public ITask
 {
@@ -19,7 +20,7 @@ public:
 	WaitingFullscreenWindow();
 	virtual ~WaitingFullscreenWindow();
 
-	void Init(int displayInd = 0);
+	void Init(const DisplayData& displayData);
 
 	void Hide();
 	void HideQuick();


### PR DESCRIPTION
My humble attempt to make Eyeleo more responsive to change in the number of displays. I use this application at work, and when I unplug one of my monitors, Eyeleo still thinks that I have two and draw extra notifications window.